### PR TITLE
Rename `try_compute_symbolreferences` to `compute_symbols_state`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Find all variables referenced and assigned in an expression. This package is use
 
 # API
 
-The main function to use is `ExpressionExplorer.compute_reactive_node(expression)`.
+The main function to use is `compute_reactive_node(expression)`, which returns a `ReactiveNode`. There is also a more low-level API available: `compute_symbols_state` returning a `SymbolsSate`.
 
 ## High-level: `ReactiveNode`
 
@@ -24,13 +24,13 @@ Base.@kwdef struct ReactiveNode
 end
 ```
 
-You can use the function `ExpressionExplorer.compute_reactive_node(expression)` to explore an expression and generate the resulting `ReactiveNode`.
+You can use the function `compute_reactive_node(expression)` to explore an expression and generate the resulting `ReactiveNode`.
 
 ## Low-level: `SymbolsSate`
 
 If you are not interested in just the *dependencies* between expressions, there is a more low-level data structure available. (We include it for completeness, but Pluto does not use this data, except to generate a `ReactiveNode`.)
 
-The function `try_compute_symbolreferences` take an expression as argument, and returns a `SymbolsState`.
+The function `compute_symbols_state` take an expression as argument, and returns a `SymbolsState`.
 
 ```julia
 Base.@kwdef mutable struct SymbolsState
@@ -109,7 +109,7 @@ Set{Symbol} with 1 element:
 
 julia> using ExpressionExplorer
 
-julia> try_compute_symbolreferences(:(a = b + c))
+julia> compute_symbols_state(:(a = b + c))
 SymbolsState(
     references=Set([:b, :c]), 
     assignments=Set([:a]), 
@@ -118,7 +118,7 @@ SymbolsState(
     macrocalls=Set{Vector{Symbol}}()
 )
 
-julia> try_compute_symbolreferences(:(a = b))
+julia> compute_symbols_state(:(a = b))
 SymbolsState(
     references=Set([:b]), 
     assignments=Set([:a]), 
@@ -127,7 +127,7 @@ SymbolsState(
     macrocalls=Set{Vector{Symbol}}()
 )
 
-julia> try_compute_symbolreferences(:(a(b) = b + c))
+julia> compute_symbols_state(:(a(b) = b + c))
 SymbolsState(
     references=Set{Symbol}(), 
     assignments=Set{Symbol}(), 

--- a/src/ExpressionExplorer.jl
+++ b/src/ExpressionExplorer.jl
@@ -1,6 +1,6 @@
 module ExpressionExplorer
 
-export compute_symbolreferences, try_compute_symbolreferences, compute_usings_imports, SymbolsState, FunctionName, join_funcname_parts
+export compute_symbols_state, compute_reactive_node, compute_usings_imports, ReactiveNode, SymbolsState, FunctionName, FunctionNameSignaturePair, join_funcname_parts
 
 include("./explore.jl")
 include("./FunctionDependencies.jl")

--- a/src/explore.jl
+++ b/src/explore.jl
@@ -1220,18 +1220,11 @@ function handle_recursive_functions!(symstate::SymbolsState)
 end
 
 """
-    compute_symbolreferences(ex::Any)::SymbolsState
+compute_symbols_state(ex::Any)::SymbolsState
 
-Return the global references, assignment, function calls and function definitions inside an arbitrary expression.
-Inside Pluto, `ex` is always an `Expr`. However, we still accept `Any` to allow people outside Pluto to use this to do syntax analysis.
+Return the global references, assignment, function calls and function definitions inside an arbitrary expression, in a `SymbolsState` object.
 """
-function compute_symbolreferences(ex::Any; configuration::AbstractExpressionExplorerConfiguration=DefaultConfiguration())::SymbolsState
-    symstate = explore!(ex, ScopeState(configuration))
-    handle_recursive_functions!(symstate)
-    return symstate
-end
-
-function try_compute_symbolreferences(ex::Any; configuration::AbstractExpressionExplorerConfiguration=DefaultConfiguration())::SymbolsState
+function compute_symbols_state(ex::Any; configuration::AbstractExpressionExplorerConfiguration=DefaultConfiguration())::SymbolsState
     try
         compute_symbolreferences(ex; configuration)
     catch e
@@ -1243,6 +1236,14 @@ function try_compute_symbolreferences(ex::Any; configuration::AbstractExpression
         SymbolsState(references = Set{Symbol}([:fake_reference_to_prevent_it_from_looking_like_a_text_only_cell]))
     end
 end
+
+function compute_symbolreferences(ex::Any; configuration::AbstractExpressionExplorerConfiguration=DefaultConfiguration())::SymbolsState
+    symstate = explore!(ex, ScopeState(configuration))
+    handle_recursive_functions!(symstate)
+    return symstate
+end
+
+@deprecate try_compute_symbolreferences(args...) compute_symbols_state(args...)
 
 Base.@kwdef struct UsingsImports
     usings::Set{Expr} = Set{Expr}()


### PR DESCRIPTION
Now the public API is a bit more clear:

> The main function to use is `compute_reactive_node(expression)`, which returns a `ReactiveNode`. There is also a more low-level API available: `compute_symbols_state` returning a `SymbolsSate`.