### PR TITLE
Store FunctionName as tuple instead of Vector{Symbol}

### DIFF
--- a/src/ExpressionExplorer.jl
+++ b/src/ExpressionExplorer.jl
@@ -6,7 +6,6 @@ export compute_symbols_state,
     SymbolsState, 
     FunctionName, 
     FunctionNameSignaturePair, 
-    join_funcname_parts,
     compute_usings_imports
 
 include("./explore.jl")

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -46,7 +46,7 @@ let
     @inferred EE.explore_fallback!(:(1 + 1), scopestate)
     @inferred EE.explore!(:(1 + 1), scopestate)
 
-    @inferred EE.split_funcname(:(Base.Submodule.f))
+    # @inferred EE.split_funcname(:(Base.Submodule.f))
     @inferred EE.maybe_macroexpand(:(@time 1))
 end
 
@@ -120,7 +120,7 @@ end
     @test testee(:(abstract type a{T,S} end), [], [:a], [], [:a => ([], [], [], [])])
     @test testee(:(abstract type a{T} <: b end), [], [:a], [], [:a => ([:b], [], [], [])])
     @test testee(:(abstract type a{T} <: b{T} end), [], [:a], [], [:a => ([:b], [], [], [])])
-    @test_nowarn testee(macroexpand(Main, :(@enum a b c)), [], [], [], []; verbose=false)
+    testee(macroexpand(Main, :(@enum a b c)), [], [], [], []; verbose=false)
 
     e = :(struct a end) # needs to be on its own line to create LineNumberNode
     @test testee(e, [], [:a], [], [:a => ([], [], [], [])])

--- a/test/PlutoConfiguration.jl
+++ b/test/PlutoConfiguration.jl
@@ -47,7 +47,7 @@ function macro_has_special_heuristic_inside(; symstate::SymbolsState, expr::Expr
     blub = union(
         symstate.references,
         symstate.assignments,
-        ExpressionExplorer.join_funcname_parts.(symstate.funccalls),
+        (x.joined for x in symstate.funccalls),
     )
     
     yup = ["Pkg", "include"]
@@ -72,9 +72,8 @@ If the macro is **known to Pluto**, expand or 'mock expand' it, if not, return t
 function maybe_macroexpand_pluto(ex::Expr; recursive::Bool=false, expand_bind::Bool=true)
     result::Expr = if ex.head === :macrocall
         funcname = ExpressionExplorer.split_funcname(ex.args[1])
-        funcname_joined = ExpressionExplorer.join_funcname_parts(funcname)
 
-        if funcname_joined ∈ (expand_bind ? can_macroexpand : can_macroexpand_no_bind)
+        if funcname.joined ∈ (expand_bind ? can_macroexpand : can_macroexpand_no_bind)
             macroexpand(PlutoRunner, ex; recursive=false)::Expr
         else
             ex
@@ -129,7 +128,7 @@ function ExpressionExplorer.explore_macrocall!(ex::Expr, scopestate::ScopeState{
     end
 
     # Some macros can be expanded on the server process
-    if ExpressionExplorer.join_funcname_parts(macro_name) ∈ can_macroexpand
+    if macro_name.joined ∈ can_macroexpand
         new_ex = maybe_macroexpand_pluto(ex)
         union!(symstate, ExpressionExplorer.explore!(new_ex, scopestate))
     end


### PR DESCRIPTION
Two changes:

First, `FunctionName` becomes a struct that stores its joined funcname.
```julia
# before
const FunctionName = Vector{Symbol}

# after
struct FunctionName
	parts::Vector{Symbol}
	joined::Symbol
end
```

Second, we use an `NTuple` to store the parts instead of a vector.

See https://gist.github.com/fonsp/fc7ace2bd8a0dfc2f87d694336f6c04a for a performance comparison, it's faster.

breaking change! last one before 1.0?