### PR TITLE
No macro expansion by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,12 @@ license = "MIT"
 authors = ["Paul Berg <paul@plutojl.org>", "Fons van der Plas <fons@plutojl.org>"]
 version = "0.3.0"
 
-[deps]
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
 [compat]
-Markdown = "1"
 julia = "1.6"
 
 [extras]
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Markdown", "Test"]

--- a/src/explore.jl
+++ b/src/explore.jl
@@ -1,5 +1,4 @@
 
-import Markdown
 import Base: union, union!, ==
 
 ###

--- a/src/explore.jl
+++ b/src/explore.jl
@@ -451,12 +451,6 @@ function explore_macrocall!(ex::Expr, scopestate::ScopeState)
         union!(symstate, SymbolsState(macrocalls = macro_symstate.macrocalls))
     end
 
-    # Some macros can be expanded on the server process
-    if macro_name.joined ∈ can_macroexpand
-        new_ex = maybe_macroexpand(ex)
-        union!(symstate, explore!(new_ex, scopestate))
-    end
-
     return symstate
 end
 
@@ -1012,45 +1006,6 @@ end
 function explore_funcdef!(::Any, ::ScopeState)::Tuple{FunctionName,SymbolsState}
     FunctionName(), SymbolsState()
 end
-
-
-module MacroExpandInHere
-using Markdown
-end
-
-const can_macroexpand = Set(Symbol.(["@md_str", "Markdown.@md_str", "@gensym", "Base.@gensym", "@enum", "Base.@enum", "@assert", "Base.@assert", "@cmd"]))
-
-"""
-If the macro is **known to Pluto**, expand or 'mock expand' it, if not, return the expression. Macros from external packages are not expanded, this is done later in the pipeline. See https://github.com/fonsp/Pluto.jl/pull/1032
-"""
-function maybe_macroexpand(ex::Expr; recursive::Bool=false)
-    result::Expr = if ex.head === :macrocall
-        funcname = split_funcname(ex.args[1])
-
-        if funcname.joined ∈ can_macroexpand
-            macroexpand(MacroExpandInHere, ex; recursive=false)::Expr
-        else
-            ex
-        end
-    else
-        ex
-    end
-
-    if recursive
-        # Not using broadcasting because that is expensive compilation-wise for `result.args::Any`.
-        expanded = Any[]
-        for arg in result.args
-            ex = maybe_macroexpand(arg; recursive)
-            push!(expanded, ex)
-        end
-        return Expr(result.head, expanded...)
-    else
-        return result
-    end
-end
-
-maybe_macroexpand(ex::Any; kwargs...) = ex
-
 
 ###
 # CANONICALIZE FUNCTION DEFINITIONS

--- a/test/Configuration.jl
+++ b/test/Configuration.jl
@@ -66,7 +66,66 @@ end
 
 
 
+@testset "Macros w/ Pluto 1" begin
+    # Macros tests are not just in ExpressionExplorer now
 
+    @test testee(:(@time a = 2), [], [], [], [], [Symbol("@time")]; configuration)
+    @test testee(:(@f(x; y=z)), [], [], [], [], [Symbol("@f")]; configuration)
+    @test testee(:(@f(x, y = z)), [], [], [], [], [Symbol("@f")]) # https://github.com/fonsp/Pluto.jl/issues/252
+    @test testee(:(Base.@time a = 2), [], [], [], [], [[:Base, Symbol("@time")]]; configuration)
+    # @test_nowarn testee(:(@enum a b = d c), [:d], [:a, :b, :c], [Symbol("@enum")], [])
+    # @enum is tested in test/React.jl instead
+    @test testee(:(@gensym a b c), [], [:a, :b, :c], [:gensym], [], [Symbol("@gensym")]; configuration)
+    @test testee(:(Base.@gensym a b c), [], [:a, :b, :c], [:gensym], [], [[:Base, Symbol("@gensym")]]; configuration)
+    @test testee(:(Base.@kwdef struct A; x = 1; y::Int = two; z end), [], [], [], [], [[:Base, Symbol("@kwdef")]]; configuration)
+    @test testee(quote "asdf" f(x) = x end, [], [], [], [], [Symbol("@doc")]; configuration)
+
+    # @test testee(:(@bind a b), [], [], [], [], [Symbol("@bind")]; configuration)
+    # @test testee(:(PlutoRunner.@bind a b), [], [], [], [], [[:PlutoRunner, Symbol("@bind")]]; configuration)
+    # @test_broken testee(:(Main.PlutoRunner.@bind a b), [:b], [:a], [[:Base, :get], [:Core, :applicable], [:PlutoRunner, :create_bond], [:PlutoRunner, Symbol("@bind")]], [], verbose=false; configuration)
+    # @test testee(:(let @bind a b end), [], [], [], [], [Symbol("@bind")]; configuration)
+
+    @test testee(:(`hey $(a = 1) $(b)`), [:b], [], [:cmd_gen], [], [Symbol("@cmd")]; configuration)
+    # @test testee(:(md"hey $(@bind a b) $(a)"), [:a], [], [[:getindex]], [], [Symbol("@md_str"), Symbol("@bind")]; configuration)
+    # @test testee(:(md"hey $(a) $(@bind a b)"), [:a], [], [[:getindex]], [], [Symbol("@md_str"), Symbol("@bind")]; configuration)
+
+    @test testee(:(@asdf a = x1 b = x2 c = x3), [], [], [], [], [Symbol("@asdf")]; configuration) # https://github.com/fonsp/Pluto.jl/issues/670
+
+    @test testee(:(@einsum a[i,j] := x[i]*y[j]), [], [], [], [], [Symbol("@einsum")]; configuration)
+    @test testee(:(@tullio a := f(x)[i+2j, k[j]] init=z), [], [], [], [], [Symbol("@tullio")]; configuration)
+    @test testee(:(Pack.@asdf a[1,k[j]] := log(x[i]/y[j])), [], [], [], [], [[:Pack, Symbol("@asdf")]]; configuration)
+
+
+    @test testee(:(html"a $(b = c)"), [], [], [], [], [Symbol("@html_str")]; configuration)
+    @test testee(:(md"a $(b = c) $(b)"), [:c], [:b], [:getindex], [], [Symbol("@md_str")]; configuration)
+    @test testee(:(md"\* $r"), [:r], [], [:getindex], [], [Symbol("@md_str")]; configuration)
+    @test testee(:(md"a \$(b = c)"), [], [], [:getindex], [], [Symbol("@md_str")]; configuration)
+    @test testee(:(macro a() end), [], [], [], [
+        Symbol("@a") => ([], [], [], [])
+    ]; configuration)
+    @test testee(:(macro a(b::Int); b end), [], [], [], [
+        Symbol("@a") => ([:Int], [], [], [])
+    ]; configuration)
+    @test testee(:(macro a(b::Int=c) end), [], [], [], [
+        Symbol("@a") => ([:Int, :c], [], [], [])
+    ]; configuration)
+    @test testee(:(macro a(); b = c; return b end), [], [], [], [
+        Symbol("@a") => ([:c], [], [], [])
+    ]; configuration)
+    @test test_expression_explorer(;
+        expr=:(@parent @child 10),
+        macrocalls=[Symbol("@parent"), Symbol("@child")],
+        configuration
+    )
+    @test test_expression_explorer(;
+        expr=:(@parent begin @child 1 + @grandchild 10 end),
+        macrocalls=[Symbol("@parent"), Symbol("@child"), Symbol("@grandchild")],
+        configuration
+    )
+    @test testee(macroexpand(Main, :(@noinline f(x) = x)), [], [], [], [
+        Symbol("f") => ([], [], [], [])
+    ]; configuration)
+end
 
 
 @testset "Macros w/ Pluto" begin

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -47,7 +47,6 @@ let
     @inferred EE.explore!(:(1 + 1), scopestate)
 
     # @inferred EE.split_funcname(:(Base.Submodule.f))
-    @inferred EE.maybe_macroexpand(:(@time 1))
 end
 
 @testset "Basics" begin
@@ -599,8 +598,8 @@ end
     @test testee(:(Base.@time a = 2), [], [], [], [], [[:Base, Symbol("@time")]])
     # @test_nowarn testee(:(@enum a b = d c), [:d], [:a, :b, :c], [Symbol("@enum")], [])
     # @enum is tested in test/React.jl instead
-    @test testee(:(@gensym a b c), [], [:a, :b, :c], [:gensym], [], [Symbol("@gensym")])
-    @test testee(:(Base.@gensym a b c), [], [:a, :b, :c], [:gensym], [], [[:Base, Symbol("@gensym")]])
+    @test testee(:(@gensym a b c), [], [], [], [], [Symbol("@gensym")])
+    @test testee(:(Base.@gensym a b c), [], [], [], [], [[:Base, Symbol("@gensym")]])
     @test testee(:(Base.@kwdef struct A; x = 1; y::Int = two; z end), [], [], [], [], [[:Base, Symbol("@kwdef")]])
     @test testee(quote "asdf" f(x) = x end, [], [], [], [], [Symbol("@doc")])
 
@@ -609,9 +608,9 @@ end
     @test_broken testee(:(Main.PlutoRunner.@bind a b), [:b], [:a], [[:Base, :get], [:Core, :applicable], [:PlutoRunner, :create_bond], [:PlutoRunner, Symbol("@bind")]], [], verbose=false)
     @test testee(:(let @bind a b end), [], [], [], [], [Symbol("@bind")])
 
-    @test testee(:(`hey $(a = 1) $(b)`), [:b], [], [:cmd_gen], [], [Symbol("@cmd")])
-    @test testee(:(md"hey $(@bind a b) $(a)"), [:a], [], [[:getindex]], [], [Symbol("@md_str"), Symbol("@bind")])
-    @test testee(:(md"hey $(a) $(@bind a b)"), [:a], [], [[:getindex]], [], [Symbol("@md_str"), Symbol("@bind")])
+    @test testee(:(`hey $(a = 1) $(b)`), [], [], [], [], [Symbol("@cmd")])
+    @test testee(:(md"hey $(@bind a b) $(a)"), [], [], [], [], [Symbol("@md_str")])
+    @test testee(:(md"hey $(a) $(@bind a b)"), [], [], [], [], [Symbol("@md_str")])
 
     @test testee(:(@asdf a = x1 b = x2 c = x3), [], [], [], [], [Symbol("@asdf")]) # https://github.com/fonsp/Pluto.jl/issues/670
 
@@ -621,9 +620,9 @@ end
 
 
     @test testee(:(html"a $(b = c)"), [], [], [], [], [Symbol("@html_str")])
-    @test testee(:(md"a $(b = c) $(b)"), [:c], [:b], [:getindex], [], [Symbol("@md_str")])
-    @test testee(:(md"\* $r"), [:r], [], [:getindex], [], [Symbol("@md_str")])
-    @test testee(:(md"a \$(b = c)"), [], [], [:getindex], [], [Symbol("@md_str")])
+    @test testee(:(md"a $(b = c) $(b)"), [], [], [], [], [Symbol("@md_str")])
+    @test testee(:(md"\* $r"), [], [], [], [], [Symbol("@md_str")])
+    @test testee(:(md"a \$(b = c)"), [], [], [], [], [Symbol("@md_str")])
     @test testee(:(macro a() end), [], [], [], [
         Symbol("@a") => ([], [], [], [])
     ])


### PR DESCRIPTION
I think this might be nicer, but we should document how to macroexpand before using EE.

Maybe we should also provide a help function that macroexpands macros that are known, but not the rest? Like

```julia
# ╔═╡ b6c56df1-a693-434a-98d7-2bb8fe185343
function trymacroexpand(e::Expr; mod::Module)
	if e.head === :macrocall
		try
			e = macroexpand(mod, e; recursive=false)
		catch ex
			@warn "failed ro expand" ex=(ex,catch_backtrace()) e.args[1]
		end
	end
	Expr(e.head, (trymacroexpand(a; mod) for a in e.args)...)
end

# ╔═╡ cdc81b89-a0f4-4de4-9b54-f959a757aca4
trymacroexpand(x::Any; mod::Module) = x
```

This works but it's a bit slow