### PR TITLE
fix the use of `end` and `begin` as part of indexing

### DIFF
--- a/src/explore.jl
+++ b/src/explore.jl
@@ -321,6 +321,10 @@ end
 function explore!(sym::Symbol, scopestate::ScopeState)::SymbolsState
     if sym ∈ scopestate.hiddenglobals
         SymbolsState()
+    elseif sym ∈ (:begin, :end)
+        # in indexing these symbols may appear. They are not globals, but syntax,
+        # hence there is no way to use these as real symbols anywhere else.
+        SymbolsState()
     else
         SymbolsState(references = Set([sym]))
     end


### PR DESCRIPTION
This is part of a little memory-leak bug which was hard to debug. 

Because `begin` and `end` had been identified as normal variable names, the use of it inside indexing causes new workspaces to be created.

I guess in normal Pluto this is not so decisive, as anyway a new workspace is created every time, but in my fork I am reusing workspaces where this appeared then.

Maybe it also helps normal Pluto users somehow. 