### PR TITLE
unescape name in uncurly!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ExpressionExplorer"
 uuid = "21656369-7473-754a-2065-74616d696c43"
 license = "MIT"
 authors = ["Paul Berg <paul@plutojl.org>", "Fons van der Plas <fons@plutojl.org>"]
-version = "1.0.3"
+version = "1.0.4"
 
 [compat]
 julia = "1.6"

--- a/src/explore.jl
+++ b/src/explore.jl
@@ -887,6 +887,9 @@ function to_kw(ex::Expr)
 end
 to_kw(x) = x
 
+unescape(x::Expr) = Meta.isexpr(x, :escape) ? x.args[1] : x
+unescape(x) = x
+
 """
 Return the function name and the SymbolsState from argument defaults. Add arguments as hidden globals to the `scopestate`.
 
@@ -975,7 +978,7 @@ function explore_funcdef!(ex::Expr, scopestate::ScopeState)::Tuple{FunctionName,
 
     elseif ex.head === :(<:)
         # for use in `struct`, `abstract` and `primitive`
-        name, symstate = uncurly!(ex.args[1], scopestate)
+        name, symstate = uncurly!(unescape(ex.args[1]), scopestate)
         if length(ex.args) != 1
             union!(symstate, explore!(ex.args[2], scopestate))
         end

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -70,6 +70,10 @@ end
     @test_nowarn testee(:(function f(function g() end) end), [], [], [:+], [], verbose=false)
     @test_nowarn testee(:(function f() Base.sqrt(x::String) = 2; end), [], [], [:+], [], verbose=false)
     @test_nowarn testee(:(function f() global g(x) = x; end), [], [], [], [], verbose=false)
+
+    @test_nowarn testee(:(primitive type $(esc(:Fruit)) <: T 32 end), [], [:Fruit], [], [
+        :Fruit => ([:T], [], [], [])
+    ])
 end
 @testset "Lists and structs" begin
     @test testee(:(1:3), [], [], [:(:)], [])
@@ -99,7 +103,9 @@ end
     @test testee(:(primitive type Int24 <: Integer size end), [:size], [:Int24], [], [
         :Int24 => ([:Integer], [], [], [])
     ])
-
+    @test_nowarn testee(:(primitive type $(esc(:Fruit)) <: T 32 end), [], [:Fruit], [], [
+        :Fruit => ([:T], [], [], [])
+    ])
     @test testee(:(module a; f(x) = x; z = r end), [], [:a], [], [])
 end
 @testset "Types" begin


### PR DESCRIPTION
this pattern should probably be generalized for more robustness but this
will remove exex failures on simple benchmarks such as `@enum Letter a b c`.
