### PR TITLE
Lower warnings to debug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ExpressionExplorer"
 uuid = "21656369-7473-754a-2065-74616d696c43"
 license = "MIT"
 authors = ["Paul Berg <paul@plutojl.org>", "Fons van der Plas <fons@plutojl.org>"]
-version = "1.1.1"
+version = "1.1.2"
 
 [compat]
 julia = "1.10"


### PR DESCRIPTION
I have an application that uses ExpressionExplorer.jl to navigate large Julia codebases and make reactive nodes. In some cases we have complex macro calls and expressions in DSLs that it fails to compute a ReactiveNode for. 

This results in many warning being printed in the console whenever we run it

This PR lowers the `@warn` statements to `@debug` in order to leave the `stderr` clean