### PR TITLE
Fix Pack.@asdf references

### DIFF
--- a/src/ReactiveNode.jl
+++ b/src/ReactiveNode.jl
@@ -51,8 +51,9 @@ function ReactiveNode(symstate::SymbolsState)
 	FunctionDependencies.maybe_add_dependent_funccalls!(funccalls)
 	union!(result.references, funccalls)
 
+	# Both the first part and the joined paths may be needed for reactivity, see PR #30.
 	macrocalls_first_part = Set{Symbol}(first(x.parts) for x in symstate.macrocalls)
-	union!(result.references, macrocalls_first_part)
+	union!(result.references, macrocalls_first_part, macrocalls_joined)
 
 	for (namesig, body_symstate) in symstate.funcdefs
 		push!(result.funcdefs_with_signatures, namesig)

--- a/test/ReactiveNode.jl
+++ b/test/ReactiveNode.jl
@@ -1,17 +1,17 @@
 @testset "ReactiveNode" begin
+    rn = compute_reactive_node(:(Pack))
+    @test rn.references == Set([:Pack])
+
     rn = ExpressionExplorer.compute_reactive_node(quote
         () -> Date
     end)
     @test :Date ∈ rn.references
 
-    rn = compute_reactive_node(:(Pack))
-    @test rn.references == Set([:Pack])
-
     rn = compute_reactive_node(:(@asdf a[1,k[j]] := log(x[i]/y[j])))
     @test rn.references == Set([Symbol("@asdf")])
     @test rn.macrocalls == Set([Symbol("@asdf")])
 
-    rn = compute_reactive_node(:(Pack.@asdf a[1,k[j]] := log(x[i]/y[j])))
-    @test rn.references == Set([:Pack, Symbol("Pack.@asdf")])
-    @test rn.macrocalls == Set([Symbol("Pack.@asdf")])
+    rn = compute_reactive_node(:(One.Two.@asdf a[1,k[j]] := log(x[i]/y[j])))
+    @test rn.references == Set([:One, Symbol("One.Two.@asdf")])
+    @test rn.macrocalls == Set([Symbol("One.Two.@asdf")])
 end

--- a/test/ReactiveNode.jl
+++ b/test/ReactiveNode.jl
@@ -3,4 +3,15 @@
         () -> Date
     end)
     @test :Date ∈ rn.references
+
+    rn = compute_reactive_node(:(Pack))
+    @test rn.references == Set([:Pack])
+
+    rn = compute_reactive_node(:(@asdf a[1,k[j]] := log(x[i]/y[j])))
+    @test rn.references == Set([Symbol("@asdf")])
+    @test rn.macrocalls == Set([Symbol("@asdf")])
+
+    rn = compute_reactive_node(:(Pack.@asdf a[1,k[j]] := log(x[i]/y[j])))
+    @test rn.references == Set([:Pack])
+    @test rn.macrocalls == Set([Symbol("Pack.@asdf")])
 end

--- a/test/ReactiveNode.jl
+++ b/test/ReactiveNode.jl
@@ -12,6 +12,6 @@
     @test rn.macrocalls == Set([Symbol("@asdf")])
 
     rn = compute_reactive_node(:(Pack.@asdf a[1,k[j]] := log(x[i]/y[j])))
-    @test rn.references == Set([:Pack])
+    @test rn.references == Set([:Pack, Symbol("Pack.@asdf")])
     @test rn.macrocalls == Set([Symbol("Pack.@asdf")])
 end


### PR DESCRIPTION
Using the `Pack.@asdf` example already present in tests (but only for symbol state, not `ReactiveNode`).

### Before
```julia-repl
julia> ex = :(Pack.@asdf);

julia> compute_reactive_node(ex).references
Set{Symbol} with 1 element:
  Symbol("Pack.@asdf")
```
This sometimes broke reactivity in Pluto because the `:(import Pack)` cell definitions were `:Pack`,
which does not match the `Pack.@asdf` in references.


### With this PR
```julia-repl
julia> compute_reactive_node(ex).references
Set{Symbol} with 1 element:
  :Pack
```

The Pluto tests pass with these changes (with  EE dev'ed),
but please check thoroughly, as I'm very new to this stuff.
