### PR TITLE
Handle escaped module names from Julia 1.12 hygienic macro expansion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ authors = ["Paul Berg <paul@plutojl.org>", "Fons van der Plas <fons@plutojl.org>
 [deps]
 
 [compat]
-Aqua = "0.8.14"
+Aqua = "0.8.14, 1"
 ExplicitImports = "1.15.0"
 julia = "1.10"
 Markdown = "1.10"

--- a/src/explore.jl
+++ b/src/explore.jl
@@ -770,7 +770,9 @@ function explore_module!(ex::Expr, scopestate::ScopeState)
     # Does create it's own scope, but can import from outer scope, that's what `explore_module_definition!` is for
     symstate = explore_module_definition!(ex, scopestate)
     module_name_num = ex.args[1] isa VersionNumber ? 3 : 2
-    return union(symstate, SymbolsState(assignments = Set{Symbol}([ex.args[module_name_num]])))::SymbolsState
+    module_name = unescape(ex.args[module_name_num])
+    assignments = module_name isa Symbol ? Set{Symbol}([module_name]) : Set{Symbol}()
+    return union(symstate, SymbolsState(assignments = assignments))::SymbolsState
 end
 
 function explore_fallback!(ex::Expr, scopestate::ScopeState)

--- a/src/explore.jl
+++ b/src/explore.jl
@@ -770,9 +770,12 @@ function explore_module!(ex::Expr, scopestate::ScopeState)
     # Does create it's own scope, but can import from outer scope, that's what `explore_module_definition!` is for
     symstate = explore_module_definition!(ex, scopestate)
     module_name_num = ex.args[1] isa VersionNumber ? 3 : 2
+    # On Julia 1.12+, hygienic macro expansion may wrap the module name in
+    # `Expr(:escape, :Name)`, so we unwrap it here. The `isa Symbol` guard
+    # skips anything we can't reduce to a plain name (e.g. interpolations).
     module_name = unescape(ex.args[module_name_num])
     assignments = module_name isa Symbol ? Set{Symbol}([module_name]) : Set{Symbol}()
-    return union(symstate, SymbolsState(assignments = assignments))::SymbolsState
+    return union(symstate, SymbolsState(; assignments))::SymbolsState
 end
 
 function explore_fallback!(ex::Expr, scopestate::ScopeState)

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -107,8 +107,21 @@ end
         :Fruit => ([:T], [], [], [])
     ])
     @test testee(:(module a; f(x) = x; z = r end), [], [:a], [], [])
-    # Julia 1.12 hygienic macro expansion wraps module names in Expr(:escape, :Name)
-    @test testee(Expr(:module, true, Expr(:escape, :a), Expr(:block)), [], [:a], [], [])
+end
+# Julia 1.12+ hygienic macro expansion can wrap module names in Expr(:escape, :Name)
+# inside Expr(Symbol("hygienic-scope"), ...) when macros use esc() with :toplevel.
+# See https://github.com/JuliaPluto/ExpressionExplorer.jl/pull/36
+macro _ee_test_enumlike(name)
+    quote
+        $(Expr(:toplevel, :(baremodule $(esc(name))
+            primitive type T 8 end
+        end)))
+    end
+end
+@testset "Macroexpanded module" begin
+    expanded = macroexpand(@__MODULE__, :(@_ee_test_enumlike TestModFromMacro))
+    # Should not error, and should detect the module definition
+    @test_nowarn ExpressionExplorer.compute_symbolreferences(expanded)
 end
 @testset "Types" begin
     @test testee(:(x::Foo = 3), [:Foo], [:x], [], [])

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -107,6 +107,8 @@ end
         :Fruit => ([:T], [], [], [])
     ])
     @test testee(:(module a; f(x) = x; z = r end), [], [:a], [], [])
+    # Julia 1.12 hygienic macro expansion wraps module names in Expr(:escape, :Name)
+    @test testee(Expr(:module, true, Expr(:escape, :a), Expr(:block)), [], [:a], [], [])
 end
 @testset "Types" begin
     @test testee(:(x::Foo = 3), [:Foo], [:x], [], [])

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -121,7 +121,7 @@ end
 @testset "Macroexpanded module" begin
     expanded = macroexpand(@__MODULE__, :(@_ee_test_enumlike TestModFromMacro))
     # Should not error, and should detect the module definition
-    @test_nowarn ExpressionExplorer.compute_symbolreferences(expanded)
+    @test testee(expanded, [], [:TestModFromMacro], [], [])
 end
 @testset "Types" begin
     @test testee(:(x::Foo = 3), [:Foo], [:x], [], [])

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -32,7 +32,7 @@ function Base.show(io::IO, s::SymbolsState)
     end
 end
 
-"Calls `ExpressionExplorer.compute_symbolreferences` on the given `expr` and test the found SymbolsState against a given one, with convient syntax.
+"Calls `ExpressionExplorer.compute_symbolreferences` on the given `expr` and test the found SymbolsState against a given one, with convenient syntax.
 
 # Example
 


### PR DESCRIPTION
Julia 1.12 wraps module names in `Expr(:escape, :Name)` during hygienic
macro expansion. This caused `explore_module!` to fail because it expected
a bare Symbol in the module name position.

Use `unescape()` to unwrap the module name before recording it as an
assignment, with a guard for non-Symbol results.

Also widen Aqua test compat to include v1 in the second commit. I can remove this change, if it is not welcomed.

This change was needed to make a notebook work with Julia 1.12 which worked previously without the change with Julia 1.11.

I used Claude Opus 4.6 to create the commit and fine-tuned it afterwards.